### PR TITLE
Add support for Colab credentials and set User-Agent for sitemap requests

### DIFF
--- a/gscwrapper/auth.py
+++ b/gscwrapper/auth.py
@@ -101,11 +101,12 @@ def generate_auth(
 
             # Get authorization URL
             auth_url, _ = flow.authorization_url(access_type='offline', prompt='consent')
-            print("""Google page will open for authorization\n
-                  Select your account and accept the permissions\n
-                  You will be redirected to a page that will show an ERROR (this is normal)\n
-                  The URL of that error page will contain the code we need
-                  """)
+            print(f"Please go to this URL to authorize the application: {auth_url}")
+            print("Google page will open for authorization.")
+            print("Select your account and accept the permissions")
+            print("You will be redirected to a page that will show an ERROR (this is normal)")
+            print("The URL of that error page will contain the code we need")
+            print("***************************************************************************")
             print("IMPORTANT: After authorizing, copy the full URL of the error page:")
             callback_url = input('Paste the full URL here: ').strip()
             if not callback_url:

--- a/gscwrapper/utils.py
+++ b/gscwrapper/utils.py
@@ -3,11 +3,12 @@ import requests
 import xml.etree.ElementTree as ET
 import validators
 
-
+USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3" 
+HEADERS = {'User-Agent': USER_AGENT}
 #function to get a response code 
 def get_response_code(url):
     try:
-        response = requests.head(url)
+        response = requests.head(url, headers=HEADERS)
         return response.status_code
     except: 
         return 'Impossible to get the response code'
@@ -31,7 +32,7 @@ def create_n_grams(text, n=2):
 
 def fetch_sitemap_content(url):
     try:
-        response = requests.get(url)
+        response = requests.get(url, headers=HEADERS)
         response.raise_for_status()
         return response.content
     except requests.RequestException as e:


### PR DESCRIPTION
- Implemented new logic to generate credentials in Colab using `localhost/callback` (closes #20).
- Added a User-Agent header to sitemap requests as a bonus improvement.